### PR TITLE
fix: set jsonrpc id when making errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # stage: build ---------------------------------------------------------
 
-FROM golang:1.22-alpine as build
+FROM golang:1.24-alpine AS build
 
 RUN apk add --no-cache gcc musl-dev linux-headers
 

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -571,7 +571,7 @@ func (p *HTTP) execProxyJob(job *proxyJob) {
 		switch utils.Str(job.req.Header.ContentType()) {
 		case "application/json":
 			job.res.SetStatusCode(fasthttp.StatusAccepted)
-			job.res.SetBody([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","error":{"code":-32042,"message":%s}}`, strconv.Quote(err.Error()))))
+			job.res.SetBody([]byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32042,"message":%s}}`, job.triage.JrpcID, strconv.Quote(err.Error()))))
 		default:
 			job.res.SetBody([]byte(err.Error()))
 			job.res.SetStatusCode(fasthttp.StatusBadGateway)


### PR DESCRIPTION
rollup-boost was frequently getting errors that looked like this:
```
Failed to get unsafe block from builder client: Parse error: missing field `id` at line 1 column ...
```
Now, this is fixed so that the `id` field is set and we can get better error messages
```
Failed to get unsafe block from builder client: client error (Connect)
```
Which is significantly more informative